### PR TITLE
Tom/full scanning with movement

### DIFF
--- a/crowd_sim/envs/utils/agent.py
+++ b/crowd_sim/envs/utils/agent.py
@@ -83,11 +83,14 @@ class Agent(object):
         max_theta = theta + dtheta
         min_theta = theta - dtheta
         # compute angles in range matching resolution constraint
-        angles = np.array(range(int(np.ceil(min_theta*resolution/(2*np.pi))), int(np.ceil(max_theta*resolution/(2*np.pi))))) * 2 * np.pi / resolution
+        angle_indexes = np.array(range(int(np.ceil(min_theta*resolution/(2*np.pi))), int(np.ceil(max_theta*resolution/(2*np.pi)))))
+        angles = angle_indexes * 2 * np.pi / resolution
         # compute distances at each angle
         distances = np.linalg.norm(r) / np.cos(np.abs(theta - angles))
-        # return dictionary of {angles : distances}
-        return dict(zip(angles.tolist(), distances.tolist()))
+        # correct angle indexes to the range (0, resolution - 1)
+        angle_indexes = np.where(angle_indexes < 0, angle_indexes + resolution, angle_indexes)
+        # return dictionary of {indexes : distances}
+        return dict(zip(angle_indexes.tolist(), distances.tolist()))
 
     def get_full_state(self):
         return FullState(self.px, self.py, self.vx, self.vy, self.radius, self.gx, self.gy, self.v_pref, self.theta)

--- a/test/crowd_sim/envs/utils/agent_test.py
+++ b/test/crowd_sim/envs/utils/agent_test.py
@@ -17,13 +17,12 @@ class AgentTest(unittest.TestCase):
             humans.append(Human(env_config, 'humans'))
             humans[i].set_position([10*x_sign[i], 10*y_sign[i]])
 
-        expected_angles = [0.7853981633974483, 2.356194490192345, -2.356194490192345, -0.7853981633974483]
         expected_distance = 14.142135623730951
 
         for i in range(4):
             scan = humans[i].get_scan(8, 0, 0)
             self.assertEqual(len(scan), 1)
-            self.assertEqual(scan[expected_angles[i]], expected_distance)
+            self.assertEqual(list(scan.values())[0], expected_distance)
 
 
 if __name__ == '__main__':

--- a/test/crowd_sim/sim_test.py
+++ b/test/crowd_sim/sim_test.py
@@ -1,0 +1,81 @@
+import unittest
+import configparser
+import numpy as np
+from test.test_configs.get_configs import get_config
+from crowd_sim.envs.utils.robot import Robot
+from crowd_sim.envs.utils.human import Human
+from crowd_sim.envs.utils.action import ActionXY, ActionRot
+
+
+# Integration tests combining multiple components across the simulation
+class SimTest(unittest.TestCase):
+
+    def test_move_robot(self):
+        # set up config
+        env_config = configparser.RawConfigParser()
+        env_config.read(get_config('env.config'))
+
+        # set up robot and params
+        dt = 0.1
+        vx = 1.
+        robot = Robot(env_config, 'robot')
+        robot.kinematics = 'holonomic'
+        robot.set_position([0., 0.])
+        robot.time_step = dt
+
+        # step through (holonomically)
+        for i in range(10):
+            robot.step(ActionXY(vx, 0.))
+            self.assertTrue(robot.px - ((i+1) * dt * vx) < 0.0001)  # allow for some accumulation error
+
+    def test_lidar_scanning(self):
+        # set up config
+        env_config = configparser.RawConfigParser()
+        env_config.read(get_config('env.config'))
+
+        # set up env
+        dt = 0.1
+        num_steps = 5
+        robot = Robot(env_config, 'robot')
+        robot.set_position([0., 0.])
+        robot.theta = 0
+        robot.time_step = dt
+        scan_res = 360
+        humans = []
+        human_positions = [[2., 0.], [0., 2.], [0., -2.]]
+        for p in human_positions:
+            humans.append(Human(env_config, 'humans'))
+            humans[-1].set_position(p)
+
+        # keep the action constant throughout sim
+        # note this is non-holonomic, v=1m/s r=0.2rad/s
+        action = ActionRot(1., 0.2)  # v, r
+
+        # get scans and robot position at each time step
+        scans = []
+        positions = []
+        for i in range(num_steps):
+            robot.step(action)  # step through sim
+            scans.append(self.scan_lidar(robot, humans, scan_res).tolist())  # take lidar scan
+            positions.append([robot.px, robot.py, robot.theta])  # log robot position
+
+    # utility function for getting a lidar scan given a robot and a list of humans
+    # TODO: factor this out, most likely into crowd_sim.py
+    def scan_lidar(self, robot, humans, res):
+        # get scan as a dictionary {angle_index : distance}
+        full_scan = {}
+        for h in humans:
+            scan = h.get_scan(res, robot.px, robot.py)
+            for angle in scan:
+                if scan[angle] < full_scan.get(angle, np.inf):
+                    full_scan[angle] = scan[angle]
+
+        # convert to array of length res, with inf at angles with no reading
+        out_scan = np.zeros(res) + np.inf
+        for k in full_scan.keys():
+            out_scan[k] = full_scan[k]
+        return out_scan
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What's Changed?**

_Updates to get_scan()_

Get scan would previously return a dictionary of the form {angle: distance}, but of course with rounding errors its going to be such a pain to query based on float values, so instead now returns {angle_index: distance} where angle_index is an integer in the range [0, resolution-1], where 0 is in the direction robot.theta, and moves anticlockwise around the robot.

_Placeholder Tests_

Few things here, so the first test_move_robot is just a basic integration test to make the robot move, which is worth looking at to understand how the original code works. Then the main thing here is the test_lidar_scanning test, which tbf isn't an actual test, it isn't asserting anything, but tests are an easy way to try out bits of code. An environment is set up with a robot at (0,0) and several humans around. The robot is then given a velocity of 1 and angular velocity of 0.2 and the environment is stepped through with a scan taken at each step. The scans are in the form of an array of length resolution, with infinity if there is no scan reading, or the distance otherwise. These arrays are indexed in the same angle_index manner mentioned earlier. 

This is made possible by the scan_lidar util function (which should be factored out later) which calls get_scan() on each human and produces a dictionary of {angle_index : distance}, but now every human is taken into account and also obscuring between humans. It then converts to an array of length equal to the resolution, filling in infinities for indexes with no value.

_Update agent test_

Simple update to agent_test because it now uses angle indexes and not angles