### PR TITLE
Tom/lidar embedding infrastructure

### DIFF
--- a/crowd_nav/embedding/lidar_embedding_cnn.py
+++ b/crowd_nav/embedding/lidar_embedding_cnn.py
@@ -42,8 +42,7 @@ class LidarEmbeddingCNN(nn.Module):
 
     def _get_conv_output_shape(self, shape):
         # Helper function to calculate the output shape of the convolutional layers
-        x = torch.rand(*shape)
-        print(x.size())
+        x = torch.rand(*shape).unsqueeze(0)
         x = self.conv1(x)
         x = self.relu1(x)
         x = self.bn1(x)
@@ -51,6 +50,7 @@ class LidarEmbeddingCNN(nn.Module):
         x = self.conv2(x)
         x = self.relu2(x)
         x = self.bn2(x)
+        x = self.maxpool2(x)
 
         return self.flatten(x).shape[1]
 
@@ -66,6 +66,6 @@ def run(image_np):
     model.eval()
 
     with torch.no_grad():
-        output = model(image_tensor)
+        output = model(image_tensor.unsqueeze(0))
 
     return output

--- a/crowd_sim/envs/utils/agent.py
+++ b/crowd_sim/envs/utils/agent.py
@@ -83,11 +83,14 @@ class Agent(object):
         max_theta = theta + dtheta
         min_theta = theta - dtheta
         # compute angles in range matching resolution constraint
-        angles = np.array(range(int(np.ceil(min_theta*resolution/(2*np.pi))), int(np.ceil(max_theta*resolution/(2*np.pi))))) * 2 * np.pi / resolution
+        angle_indexes = np.array(range(int(np.ceil(min_theta * resolution / (2 * np.pi))), int(np.ceil(max_theta * resolution / (2 * np.pi)))))
+        angles = angle_indexes * 2 * np.pi / resolution
         # compute distances at each angle
         distances = np.linalg.norm(r) / np.cos(np.abs(theta - angles))
-        # return dictionary of {angles : distances}
-        return dict(zip(angles.tolist(), distances.tolist()))
+        # correct angle indexes to the range (0, resolution - 1)
+        angle_indexes = np.where(angle_indexes < 0, angle_indexes + resolution, angle_indexes)
+        # return dictionary of {indexes : distances}
+        return dict(zip(angle_indexes.tolist(), distances.tolist()))
 
     def get_full_state(self):
         return FullState(self.px, self.py, self.vx, self.vy, self.radius, self.gx, self.gy, self.v_pref, self.theta)

--- a/crowd_sim/envs/utils/lidar.py
+++ b/crowd_sim/envs/utils/lidar.py
@@ -2,12 +2,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def scan_lidar(self):
+def scan_lidar(robot, humans, res):
     # get scan as a dictionary {angle_index : distance}
-    res = self.scan_points
     full_scan = {}
-    for h in self.humans:
-        scan = h.get_scan(res, self.robot.px, self.robot.py)
+    for h in humans:
+        scan = h.get_scan(res, robot.px, robot.py)
         for angle in scan:
             if scan[angle] < full_scan.get(angle, np.inf):
                 full_scan[angle] = scan[angle]
@@ -19,24 +18,23 @@ def scan_lidar(self):
     return out_scan
 
 
-def scan_to_points(self, scan):
+def scan_to_points(scan, robot):
     coords = []
     for i in range(len(scan)):
         if scan[i] != np.inf:
             coords.append(
-                [self.robot.px + scan[i] * np.cos(np.deg2rad(i)), self.robot.py + scan[i] * np.sin(np.deg2rad(i))])
+                [robot.px + scan[i] * np.cos(np.deg2rad(i)), robot.py + scan[i] * np.sin(np.deg2rad(i))])
 
     return coords
 
 
-def shift_scan (self, scan, time_step):
+def shift_scan(robot, prev_angle, scan, time_step):
 
-    delta_x = self.robot.vx * time_step
-    delta_y = self.robot.vy * time_step
+    delta_x = robot.vx * time_step
+    delta_y = robot.vy * time_step
     heading_angle = np.atan2(delta_y, delta_x)
 
-    rotation = heading_angle - self.previous_angle
-    self.previous_angle = heading_angle
+    rotation = heading_angle - prev_angle
     shifted = scan + rotation/(2*np.pi)
 
     return shifted

--- a/crowd_sim/envs/utils/lidar.py
+++ b/crowd_sim/envs/utils/lidar.py
@@ -18,12 +18,12 @@ def scan_lidar(robot, humans, res):
     return out_scan
 
 
-def scan_to_points(scan, robot):
+def scan_to_points(scan, robot, res):
     coords = []
     for i in range(len(scan)):
         if scan[i] != np.inf:
             coords.append(
-                [robot.px + scan[i] * np.cos(np.deg2rad(i)), robot.py + scan[i] * np.sin(np.deg2rad(i))])
+                [robot.px + scan[i] * np.cos(np.deg2rad(360*i/res)), robot.py + scan[i] * np.sin(np.deg2rad(360*i/res))])
 
     return coords
 
@@ -40,7 +40,7 @@ def shift_scan(robot, prev_angle, scan, time_step):
     return shifted
 
 
-def construct_img (self, scans):
+def construct_img (scans):
 
     # Normalize
     d_min = np.min(scans)

--- a/crowd_sim/envs/utils/lidar.py
+++ b/crowd_sim/envs/utils/lidar.py
@@ -42,10 +42,17 @@ def shift_scan(robot, prev_angle, scan, time_step):
 
 def construct_img (scans):
 
+    # Remove any infs from scans
+    scans = np.array(scans)
+    scans = np.where(scans == np.inf, 5., scans) # todo: some more logic/ intuition on the max value here
+
     # Normalize
     d_min = np.min(scans)
     d_max = np.max(scans)
-    intensities = ((scans - d_min) * 255 / (d_max - d_min)).astype(np.uint8)
+    diff = d_max - d_min
+    if diff == 0:
+        diff = 1
+    intensities = ((scans - d_min) * 255 / diff).astype(np.uint8)
 
     # Create the image
     cmap = plt.cm.viridis

--- a/crowd_sim/envs/utils/lidar.py
+++ b/crowd_sim/envs/utils/lidar.py
@@ -15,6 +15,7 @@ def scan_lidar(robot, humans, res):
     out_scan = np.zeros(res) + np.inf
     for k in full_scan.keys():
         out_scan[k] = full_scan[k]
+    out_scan = np.roll(out_scan, -1*int(np.round(np.rad2deg(robot.theta))))
     return out_scan
 
 
@@ -26,18 +27,6 @@ def scan_to_points(scan, robot, res):
                 [robot.px + scan[i] * np.cos(np.deg2rad(360*i/res)), robot.py + scan[i] * np.sin(np.deg2rad(360*i/res))])
 
     return coords
-
-
-def shift_scan(robot, prev_angle, scan, time_step):
-
-    delta_x = robot.vx * time_step
-    delta_y = robot.vy * time_step
-    heading_angle = np.atan2(delta_y, delta_x)
-
-    rotation = heading_angle - prev_angle
-    shifted = scan + rotation/(2*np.pi)
-
-    return shifted
 
 
 def construct_img (scans):

--- a/test/crowd_nav/embedding/lidar_embedding_cnn_test.py
+++ b/test/crowd_nav/embedding/lidar_embedding_cnn_test.py
@@ -1,0 +1,46 @@
+import unittest
+import configparser
+from crowd_sim.envs.utils.robot import Robot
+from crowd_sim.envs.utils.human import Human
+from crowd_sim.envs.utils.lidar import *
+from crowd_sim.envs.utils.action import ActionRot
+from test.test_configs.get_configs import get_config
+from crowd_nav.embedding.lidar_embedding_cnn import run
+
+
+class LidarEmbeddingCNNTest(unittest.TestCase):
+    """
+    There isn't much testing that can be done on the embedding
+    output, but this ensures we can do a forward pass of the
+    network without errors
+    """
+    def test_embedding_cnn(self):
+        env_config = configparser.RawConfigParser()
+        env_config.read(get_config('env.config'))
+        human_positions = [[1, 0], [2, 0], [-1, 0], [-2, 0]]
+        self.humans = []
+        self.robot = Robot(env_config, 'robot')
+        self.robot.time_step = 0.1
+        self.robot.set_position([0, 0])
+        self.robot.theta = 0.
+        for i in range(4):
+            self.humans.append(Human(env_config, 'humans'))
+            self.humans[i].set_position(human_positions[i])
+
+        scans = []
+        vx = 0.
+        w = 0.1
+        res = 360
+        for i in range(100):
+            self.robot.step(ActionRot(vx, w))
+            scans.append(scan_lidar(self.robot, self.humans, res))
+
+        img = construct_img(scans)
+
+        network_output = run(img)
+
+        self.assertEqual(True, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/crowd_sim/envs/utils/lidar_img_demo.py
+++ b/test/crowd_sim/envs/utils/lidar_img_demo.py
@@ -1,0 +1,45 @@
+import unittest
+import configparser
+from crowd_sim.envs.utils.robot import Robot
+from crowd_sim.envs.utils.human import Human
+from crowd_sim.envs.utils.lidar import *
+from crowd_sim.envs.utils.action import ActionRot
+from test.test_configs.get_configs import get_config
+
+
+class LidarImgDemo:
+    def __init__(self):
+        self._reset()
+
+    def _reset(self):
+        self.res = 4
+        env_config = configparser.RawConfigParser()
+        env_config.read(get_config('env.config'))
+        human_positions = [[1, 0], [2, 0], [-1, 0], [-2, 0]]
+        self.humans = []
+        self.robot = Robot(env_config, 'robot')
+        self.robot.time_step = 0.1
+        self.robot.set_position([0, 0])
+        self.robot.theta = 0.
+        for i in range(4):
+            self.humans.append(Human(env_config, 'humans'))
+            self.humans[i].set_position(human_positions[i])
+
+    def test_construct_img(self):
+        self._reset()
+        scans = []
+        vx = 0.
+        w = 0.1
+        res = 360
+        for i in range(100):
+            self.robot.step(ActionRot(vx, w))
+            scans.append(scan_lidar(self.robot, self.humans, res))
+
+        return construct_img(scans)
+
+
+if __name__ == '__main__':
+    demo = LidarImgDemo()
+    img = demo.test_construct_img()
+    plt.imshow(img)
+    plt.show()

--- a/test/crowd_sim/envs/utils/lidar_test.py
+++ b/test/crowd_sim/envs/utils/lidar_test.py
@@ -1,0 +1,38 @@
+import unittest
+import configparser
+from crowd_sim.envs.utils.robot import Robot
+from crowd_sim.envs.utils.human import Human
+from crowd_sim.envs.utils.lidar import *
+from crowd_sim.envs.utils.action import ActionRot
+from test.test_configs.get_configs import get_config
+import matplotlib.pyplot as plt
+
+
+class LidarTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(LidarTest, self).__init__(*args, **kwargs)
+        self.res = 4
+        env_config = configparser.RawConfigParser()
+        env_config.read(get_config('env.config'))
+        human_positions = [[1, 0], [2, 0], [-1, 0], [-2, 0]]
+        self.humans = []
+        self.robot = Robot(env_config, 'robot')
+        self.robot.time_step = 0.1
+        self.robot.set_position([0, 0])
+        self.robot.theta = 0.
+        for i in range(4):
+            self.humans.append(Human(env_config, 'humans'))
+            self.humans[i].set_position(human_positions[i])
+
+    def test_scan_lidar(self):
+        scan = scan_lidar(self.robot, self.humans, self.res)
+        self.assertListEqual(list(scan), [1., np.inf, 1., np.inf])
+
+    def test_scan_to_points(self):
+        scan = scan_lidar(self.robot, self.humans, self.res)
+        points = scan_to_points(scan, self.robot, self.res)
+        self.assertTrue(np.linalg.norm(np.array(points) - np.array([[1., 0.], [-1., 0.]])) < 0.01)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This has all things lidar to ensure we have correct scanning, the ability to generate lidar images, and a CNN to embed. From here I think we should work backwards from the network level, i.e. update the GRU network so it takes in a lidar embedding, then we create a policy that creates a lidar image and feeds this into the network, and only then do we write the code to generate a lidar image at each step, with thought put into how many steps we go back, etc.